### PR TITLE
Fix FutureWarning and add some error checking and warnings

### DIFF
--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -48,7 +48,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
             "does not seems to be referenced to a common average reference (CAR). "
             "ICLabel was designed to classify features extracted from an EEG dataset "
             "referenced to a CAR (see the 'set_eeg_reference()' method for Raw and "
-            "Epochs instances."
+            "Epochs instances)."
         )
     if inst.info["highpass"] != 1 or inst.info["lowpass"] != 100:
         warn(
@@ -56,7 +56,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
             "is not filtered between 1 and 100 Hz. "
             "ICLabel was designed to classify features extracted from an EEG dataset "
             "bandpass filtered between 1 and 100 Hz (see the 'filter()' method for Raw "
-            "and Epochs instances."
+            "and Epochs instances)."
         )
 
     icawinv, _ = _retrieve_eeglab_icawinv(ica)

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -7,8 +7,8 @@ from mne.preprocessing import ICA
 from numpy.typing import NDArray
 from scipy.signal import resample_poly
 
-from .utils import _gdatav4, _mne_to_eeglab_locs, _next_power_of_2, _pol2cart
 from ..utils import _validate_inst_and_ica
+from .utils import _gdatav4, _mne_to_eeglab_locs, _next_power_of_2, _pol2cart
 
 
 def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -4,6 +4,7 @@ import numpy as np
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
+from mne.utils import _validate_type
 from numpy.typing import NDArray
 from scipy.signal import resample_poly
 
@@ -35,6 +36,9 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     ----------
     .. footbibliography::
     """
+    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
+    _validate_type(ica, ICA, 'ica')
+
     icawinv, _ = _retrieve_eeglab_icawinv(ica)
     icaact = _compute_ica_activations(inst, ica)
 

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -4,11 +4,11 @@ import numpy as np
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
-from mne.utils import _validate_type
 from numpy.typing import NDArray
 from scipy.signal import resample_poly
 
 from .utils import _gdatav4, _mne_to_eeglab_locs, _next_power_of_2, _pol2cart
+from ..utils import _validate_inst_and_ica
 
 
 def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
@@ -36,8 +36,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     ----------
     .. footbibliography::
     """
-    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
-    _validate_type(ica, ICA, 'ica')
+    _validate_inst_and_ica(inst, ica)
 
     icawinv, _ = _retrieve_eeglab_icawinv(ica)
     icaact = _compute_ica_activations(inst, ica)

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -42,18 +42,22 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     # TODO: 'custom_ref_applied' does not necessarily correspond to a CAR reference.
     # At the moment, the reference of the EEG data is not stored in the info.
     # c.f. https://github.com/mne-tools/mne-python/issues/8962
-    if inst.info['custom_ref_applied'] == False:
-        warn(f"The provided {'Raw' if isinstance(inst, BaseRaw) else 'Epochs'} instance "
-             "does not seems to be referenced to a common average reference (CAR). "
-             "ICLabel was designed to classify features extracted from an EEG dataset "
-             "referenced to a CAR (see the 'set_eeg_reference()' method for Raw and "
-             "Epochs instances.")
-    if inst.info['highpass'] != 1 or inst.info['lowpass'] != 100:
-        warn(f"The provided {'Raw' if isinstance(inst, BaseRaw) else 'Epochs'} instance "
-             "is not filtered between 1 and 100 Hz. "
-             "ICLabel was designed to classify features extracted from an EEG dataset "
-             "bandpass filtered between 1 and 100 Hz (see the 'filter()' method for Raw "
-             "and Epochs instances.")
+    if inst.info["custom_ref_applied"] == False:
+        warn(
+            f"The provided {'Raw' if isinstance(inst, BaseRaw) else 'Epochs'} instance "
+            "does not seems to be referenced to a common average reference (CAR). "
+            "ICLabel was designed to classify features extracted from an EEG dataset "
+            "referenced to a CAR (see the 'set_eeg_reference()' method for Raw and "
+            "Epochs instances."
+        )
+    if inst.info["highpass"] != 1 or inst.info["lowpass"] != 100:
+        warn(
+            f"The provided {'Raw' if isinstance(inst, BaseRaw) else 'Epochs'} instance "
+            "is not filtered between 1 and 100 Hz. "
+            "ICLabel was designed to classify features extracted from an EEG dataset "
+            "bandpass filtered between 1 and 100 Hz (see the 'filter()' method for Raw "
+            "and Epochs instances."
+        )
 
     icawinv, _ = _retrieve_eeglab_icawinv(ica)
     icaact = _compute_ica_activations(inst, ica)

--- a/mne_icalabel/iclabel/features.py
+++ b/mne_icalabel/iclabel/features.py
@@ -42,7 +42,7 @@ def get_iclabel_features(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     # TODO: 'custom_ref_applied' does not necessarily correspond to a CAR reference.
     # At the moment, the reference of the EEG data is not stored in the info.
     # c.f. https://github.com/mne-tools/mne-python/issues/8962
-    if inst.info["custom_ref_applied"] == False:
+    if inst.info["custom_ref_applied"] == 0:
         warn(
             f"The provided {'Raw' if isinstance(inst, BaseRaw) else 'Epochs'} instance "
             "does not seems to be referenced to a common average reference (CAR). "

--- a/mne_icalabel/iclabel/label_components.py
+++ b/mne_icalabel/iclabel/label_components.py
@@ -4,7 +4,6 @@ from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
 
-from ..utils import _validate_inst_and_ica
 from .features import get_iclabel_features
 from .network import run_iclabel
 
@@ -41,7 +40,6 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     ----------
     .. footbibliography::
     """
-    _validate_inst_and_ica(inst, ica)
     features = get_iclabel_features(inst, ica)
     labels = run_iclabel(*features)
     return labels

--- a/mne_icalabel/iclabel/label_components.py
+++ b/mne_icalabel/iclabel/label_components.py
@@ -3,10 +3,10 @@ from typing import Union
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
-from mne.utils import _validate_type
 
 from .features import get_iclabel_features
 from .network import run_iclabel
+from ..utils import _validate_inst_and_ica
 
 
 def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
@@ -41,9 +41,7 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     ----------
     .. footbibliography::
     """
-    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
-    _validate_type(ica, ICA, 'ica')
-
+    _validate_inst_and_ica(inst, ica)
     features = get_iclabel_features(inst, ica)
     labels = run_iclabel(*features)
     return labels

--- a/mne_icalabel/iclabel/label_components.py
+++ b/mne_icalabel/iclabel/label_components.py
@@ -3,6 +3,7 @@ from typing import Union
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
+from mne.utils import _validate_type
 
 from .features import get_iclabel_features
 from .network import run_iclabel
@@ -40,6 +41,9 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     ----------
     .. footbibliography::
     """
+    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
+    _validate_type(ica, ICA, 'ica')
+
     features = get_iclabel_features(inst, ica)
     labels = run_iclabel(*features)
     return labels

--- a/mne_icalabel/iclabel/label_components.py
+++ b/mne_icalabel/iclabel/label_components.py
@@ -4,9 +4,9 @@ from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
 
+from ..utils import _validate_inst_and_ica
 from .features import get_iclabel_features
 from .network import run_iclabel
-from ..utils import _validate_inst_and_ica
 
 
 def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA):

--- a/mne_icalabel/iclabel/tests/test_features.py
+++ b/mne_icalabel/iclabel/tests/test_features.py
@@ -103,7 +103,6 @@ kwargs = {"raw": dict(preload=True), "epo": dict()}
 
 # ----------------------------------------------------------------------------
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
     "file, psd_constant_file, eeglab_feature_file",
     [
@@ -180,7 +179,6 @@ def test_compute_ica_activations(file, eeglab_result_file):
 
 # ----------------------------------------------------------------------------
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
     "file, eeglab_result_file",
     [(raw_eeglab_path, raw_topo1_path), (epo_eeglab_path, epo_topo1_path)],
@@ -206,7 +204,6 @@ def test_topoplotFast(file, eeglab_result_file):
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
     "file, eeglab_result_file",
     [

--- a/mne_icalabel/iclabel/tests/test_label_components.py
+++ b/mne_icalabel/iclabel/tests/test_label_components.py
@@ -18,7 +18,6 @@ ica.fit(raw)
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = label_components(raw, ica)

--- a/mne_icalabel/iclabel/tests/test_utils.py
+++ b/mne_icalabel/iclabel/tests/test_utils.py
@@ -53,7 +53,6 @@ def test_loc(file, eeglab_result_file):
 
 # TODO: Warnings should be fixed at some point.
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("file", (gdatav4_raw_path, gdatav4_epo_path))
 def test_gdatav4(file):
     """Test grid data interpolation."""

--- a/mne_icalabel/iclabel/utils.py
+++ b/mne_icalabel/iclabel/utils.py
@@ -131,7 +131,7 @@ def _gdatav4(
     g = np.square(d) * (np.log(d) - 1)  # % Green's function.
     # Fixup value of Green's function along diagonal
     np.fill_diagonal(g, 0)
-    weights = np.linalg.lstsq(g, v)[0]
+    weights = np.linalg.lstsq(g, v, rcond=-1)[0]
 
     m, n = xq.shape
     vq = np.zeros(xq.shape)

--- a/mne_icalabel/label_components.py
+++ b/mne_icalabel/label_components.py
@@ -3,6 +3,7 @@ from typing import Union
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.preprocessing import ICA
+from mne.utils import _validate_type
 from mne.utils.check import _check_option
 
 from .iclabel import label_components as label_components_iclabel
@@ -31,5 +32,8 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA, method: str):
     labels : np.ndarray of shape (n_components,)
         The estimated numerical labels of each ICA component.
     """
+    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
+    _validate_type(ica, ICA, 'ica')
+    _validate_type(method, str, 'method')
     _check_option("method", method, methods)
     return methods[method](inst, ica)

--- a/mne_icalabel/label_components.py
+++ b/mne_icalabel/label_components.py
@@ -33,7 +33,7 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA, method: str):
     labels : np.ndarray of shape (n_components,) or (n_components, n_class)
         The estimated numerical labels of each ICA component.
     """
-    _validate_type(method, str, 'method')
+    _validate_type(method, str, "method")
     _check_option("method", method, methods)
     _validate_inst_and_ica(inst, ica)
     return methods[method](inst, ica)

--- a/mne_icalabel/label_components.py
+++ b/mne_icalabel/label_components.py
@@ -7,6 +7,7 @@ from mne.utils import _validate_type
 from mne.utils.check import _check_option
 
 from .iclabel import label_components as label_components_iclabel
+from .utils import _validate_inst_and_ica
 
 methods = {
     "iclabel": label_components_iclabel,
@@ -20,20 +21,19 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA, method: str):
     Parameters
     ----------
     inst : Raw | Epochs
-        The data instance.
+        The data instance used to fit the ICA instance.
     ica : ICA
         The fitted ICA instance.
     method : str
         The proposed method for labeling components. Must be one of
-        ('iclabel',).
+        ('iclabel', ).
 
     Returns
     -------
-    labels : np.ndarray of shape (n_components,)
+    labels : np.ndarray of shape (n_components,) or (n_components, n_class)
         The estimated numerical labels of each ICA component.
     """
-    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
-    _validate_type(ica, ICA, 'ica')
     _validate_type(method, str, 'method')
     _check_option("method", method, methods)
+    _validate_inst_and_ica(inst, ica)
     return methods[method](inst, ica)

--- a/mne_icalabel/tests/test_label_components.py
+++ b/mne_icalabel/tests/test_label_components.py
@@ -18,7 +18,6 @@ ica.fit(raw)
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_label_components():
     """Simple test to check that label_components runs without raising."""
     labels = label_components(raw, ica, method="iclabel")

--- a/mne_icalabel/tests/test_utils.py
+++ b/mne_icalabel/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_validate_inst_and_ica():
 
     # to avoid RuntimeWarning with fitting an unfiltered raw, let's fake the filter
     with raw.info._unlock():
-        raw.info['highpass'] = 1.0
+        raw.info["highpass"] = 1.0
     ica.fit(raw)
     # test valid
     _validate_inst_and_ica(raw, ica)

--- a/mne_icalabel/tests/test_utils.py
+++ b/mne_icalabel/tests/test_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+from mne import create_info
+from mne.io import RawArray
+from mne.preprocessing import ICA
+
+from mne_icalabel.utils import _validate_inst_and_ica
+
+
+def test_validate_inst_and_ica():
+    """Test that validate_inst_and_ica correctly raises."""
+    # check types
+    with pytest.raises(TypeError, match="inst must be an instance of Raw or Epochs"):
+        _validate_inst_and_ica(101, ICA())
+
+    raw = RawArray(np.random.randint(1, 10, (3, 1000)), create_info(3, 100, "eeg"))
+    with pytest.raises(TypeError, match="ica must be an instance of ICA"):
+        _validate_inst_and_ica(raw, 101)
+
+    # test unfitted
+    ica = ICA(n_components=3, method="picard")
+    with pytest.raises(RuntimeError, match="The provided ICA instance was not fitted."):
+        _validate_inst_and_ica(raw, ica)
+
+    # to avoid RuntimeWarning with fitting an unfiltered raw, let's fake the filter
+    with raw.info._unlock():
+        raw.info['highpass'] = 1.0
+    ica.fit(raw)
+    # test valid
+    _validate_inst_and_ica(raw, ica)

--- a/mne_icalabel/utils.py
+++ b/mne_icalabel/utils.py
@@ -2,14 +2,17 @@ from typing import Union
 
 from mne import BaseEpochs
 from mne.io import BaseRaw
+from mne.preprocessing import ICA
+from mne.utils import _validate_type
 
 
 def _validate_inst_and_ica(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
     """Make sure that the provided instance and ICA are valid."""
-    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
-    _validate_type(ica, ICA, 'ica')
+    _validate_type(inst, (BaseRaw, BaseEpochs), "inst", "Raw or Epochs")
+    _validate_type(ica, ICA, "ica")
 
-    if ica.current_fit == 'unfitted':
+    if ica.current_fit == "unfitted":
         raise RuntimeError(
             "The provided ICA instance was not fitted. Please use the '.fit()' method to "
-            "determine the independent components before trying to label them.")
+            "determine the independent components before trying to label them."
+        )

--- a/mne_icalabel/utils.py
+++ b/mne_icalabel/utils.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+from mne import BaseEpochs
+from mne.io import BaseRaw
+
+
+def _validate_inst_and_ica(inst: Union[BaseRaw, BaseEpochs], ica: ICA):
+    """Make sure that the provided instance and ICA are valid."""
+    _validate_type(inst, (BaseRaw, BaseEpochs), 'inst', 'Raw or Epochs')
+    _validate_type(ica, ICA, 'ica')
+
+    if ica.current_fit == 'unfitted':
+        raise RuntimeError(
+            "The provided ICA instance was not fitted. Please use the '.fit()' method to "
+            "determine the independent components before trying to label them.")


### PR DESCRIPTION
I fixed the FutureWarning by adding `rcond=-1` to keep the old behavior which seems to match with MATLAB.
I also added some error checking for the arguments provided to the public functions.

-> `mne_icalabel/utils.py`: functions and error checking that could be used for all models.
-> `mne_icalabel/iclabel/features:get_iclabel_features`: I added additional error checking for ICLabel here, using the MNE logger/warning. I did not add it to `mne_icalabel/iclabel/label_components`, since it will have to run through `get_iclabel_features` anyway.