### PR TITLE
Doc improvements

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,24 +25,23 @@ Most-used functions
 ICLabel
 =======
 
-This is the model originally available in `EEGLab <https://github.com/sccn/ICLabel>`_.
-The model was ported using matconvnet.
+This is the model originally available for `EEGLab <https://github.com/sccn/ICLabel>`_.
+The model was ported from matconvnet using `pytorch <https://pytorch.org/>`_.
 
-Architecture in matconvnet:
+Architecture:
 
 .. image:: _static/ICLabel_DagNN_Architecture.png
    :width: 400
    :alt: ICLabel Neural Network Architecture
 
 The model has three inputs: image, psd, and autocorrelation features. To encourage generalization, the image
-features are rotated and negated to quadruple the image features. The psd and autocorrelation features
+features are rotated and negated, thus quadrupling the feature. The psd and autocorrelation features
 are copied to the new image features. Then, the predicted probabilities are averaged over all four images.
 
 .. currentmodule:: mne_icalabel.iclabel
-   
+
 .. autosummary::
    :toctree: generated/
 
    get_iclabel_features
    run_iclabel
-   

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@ License
 -------
 
 **mne-icalabel** is licensed under `BSD 3.0 <https://opensource.org/licenses/BSD-3-Clause>`_.
-A full copy of the license can be found `on GitHub <https://github.com/adam2392/mne-icalabel/blob/main/LICENSE>`_.
+A full copy of the license can be found `on GitHub <https://raw.githubusercontent.com/mne-tools/mne-icalabel/main/LICENSE>`_.
 
 Indices and tables
 ------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -9,11 +9,7 @@ Dependencies
 * ``mne`` (>=1.0)
 * ``numpy`` (>=1.14)
 * ``scipy`` (>=1.5.0)
-* ``joblib`` (>=1.0.0)
-* ``scikit-learn`` (>=1.1)
 * ``torch`` (for running pytorch neural networks)
-* ``python-picard`` (for running ICA)
-* ``matplotlib`` (optional, for using the interactive data inspector)
 
 We require that you use Python 3.8 or higher.
 You may choose to install ``mne-icalabel`` `via pip <#Installation via pip>`_,

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -21,7 +21,7 @@ def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     else:
         slug = 'issues/' + text
     text = '#' + text
-    ref = 'https://github.com/mne-tools/mne-connectivity/' + slug
+    ref = 'https://github.com/mne-tools/mne-icalabel/' + slug
     set_classes(options)
     node = reference(rawtext, text, refuri=ref, **options)
     return [node], []

--- a/doc/whats_new_previous_releases.rst
+++ b/doc/whats_new_previous_releases.rst
@@ -2,7 +2,7 @@
 
 .. _whats_new_in_previous_releases:
 
-.. currentmodule:: mne_connectivity
+.. currentmodule:: mne_icalabel
 
 What was new in previous releases?
 ==================================

--- a/mne_icalabel/label_components.py
+++ b/mne_icalabel/label_components.py
@@ -23,8 +23,8 @@ def label_components(inst: Union[BaseRaw, BaseEpochs], ica: ICA, method: str):
     ica : ICA
         The fitted ICA instance.
     method : str
-        The proposed method for labeling components. Must be one of
-        ('iclabel',).
+        The proposed method for labeling components. Must be one of:
+        ``'iclabel'``.
 
     Returns
     -------


### PR DESCRIPTION
Some minor doc improvements. in `API.rst`, I would rework this paragraph as well:

> The model has three inputs: image, psd, and autocorrelation features. To encourage generalization, the image
> features are rotated and negated, thus quadrupling the feature. The psd and autocorrelation features
> are copied to the new image features. Then, the predicted probabilities are averaged over all four images.
